### PR TITLE
Check readinessGates when counting healthy pods for PDBs

### DIFF
--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -305,13 +305,14 @@ func IsPodAvailable(pod *v1.Pod, minReadySeconds int32, now metav1.Time) bool {
 
 // IsPodReady returns true if a pod is ready; false otherwise.
 func IsPodReady(pod *v1.Pod) bool {
-	return IsPodReadyConditionTrue(pod.Status) && ArePodReadinessGatesTrue(pod)
+	return IsPodReadyConditionTrue(pod.Status)
 }
 
 // ArePodReadinessGatesTrue returns true if all readiness gates return true; false otherwise.
 func ArePodReadinessGatesTrue(pod *v1.Pod) bool {
+	// if there are no readiness gates, then return true.
 	if pod.Spec.ReadinessGates == nil {
-		return false
+		return true
 	}
 
 	for _, readinessGate := range pod.Spec.ReadinessGates {

--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -311,7 +311,7 @@ func IsPodReady(pod *v1.Pod) bool {
 // ArePodReadinessGatesTrue returns true if all readiness gates return true; false otherwise.
 func ArePodReadinessGatesTrue(pod *v1.Pod) bool {
 	// if there are no readiness gates, then return true.
-	if pod.Spec.ReadinessGates == nil {
+	if pod.Spec.ReadinessGates == nil || len(pod.Spec.ReadinessGates) == 0 {
 		return true
 	}
 
@@ -326,14 +326,8 @@ func ArePodReadinessGatesTrue(pod *v1.Pod) bool {
 // IsPodReadinessGateConditionTrue returns true if the provided readiness gate
 // contition exists and is true; false otherwise.
 func IsPodReadinessGateConditionTrue(conditionType v1.PodConditionType, status v1.PodStatus) bool {
-	index, condition := GetPodCondition(&status, conditionType)
-	if index == -1 {
-		return false
-	}
-	if condition != nil && condition.Status == v1.ConditionTrue {
-		return true
-	}
-	return false
+	_, condition := GetPodCondition(&status, conditionType)
+	return condition != nil && condition.Status == v1.ConditionTrue
 }
 
 // IsPodTerminal returns true if a pod is terminal, all containers are stopped and cannot ever regress.

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -916,7 +916,7 @@ func countHealthyPods(pods []*v1.Pod, disruptedPods map[string]metav1.Time, curr
 		if disruptionTime, found := disruptedPods[pod.Name]; found && disruptionTime.Time.Add(DeletionTimeout).After(currentTime) {
 			continue
 		}
-		if apipod.IsPodReady(pod) {
+		if apipod.IsPodReady(pod) && apipod.ArePodReadinessGatesTrue(pod) {
 			currentHealthy++
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces Pod ReadinessGate checks when counting healthy pods to update PDB statuses. Now, if a pod is not passing its ReadinessGates, it will not count as healthy.

This PR also adds functions to check the status of Pods' ReadinessGates and their respective unit tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
According to [Status for Pod Readiness](storage-8xl-1cfe-datadog-mcd-24-to-31), a pod that defines ReadinessGates should only evaluate to ready once all containers in the Pod are ready and all conditions specified in readinessGates are True. Thus, healthy pods should be passing all their ReadinessGates. This PR ensures that ReadinessGates are evaluated when counting healthy pods so that pods failing their ReadinessGates will take up healthy PDB budget.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update PDB's checkHealthyPods to evaluate Pods' ReadinessGates in addition the the Ready condition
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
